### PR TITLE
Sync operation support, and custom repo paths as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ npm install --save git-latest-tag
 ### Use a callback
 
 ```js
-var getLatestTag = require('git-latest-tag').getLatestTag;
+var getLatestTag = require('git-latest-tag');
 var options = {
   all: 'ok',
   contains: true,
@@ -30,7 +30,7 @@ getLatestTag(options, function(err, tag) {
 ### Use as a readable stream
 
 ```js
-var getLatestTag = require('git-latest-tag').getLatestTag;
+var getLatestTag = require('git-latest-tag');
 var options = {
   all: 'ok',
   contains: true,
@@ -45,7 +45,7 @@ getLatestTag(options)
 ### Use it synchronously
 
 ```js
-var getLatestTagSync = require('git-latest-tag').getLatestTagSync;
+var getLatestTagSync = require('git-latest-tag').sync;
 var options = {
   all: 'ok',
   contains: true,

--- a/README.md
+++ b/README.md
@@ -2,20 +2,18 @@
 
 > Get the most recent git tag of your repository using git-describe(1)
 
-
 ## Install
 
 ```sh
 $ npm install --save git-latest-tag
 ```
 
-
 ## Usage
 
 ### Use a callback
 
 ```js
-var getLatestTag = require('git-latest-tag');
+var getLatestTag = require('git-latest-tag').getLatestTag;
 var options = {
   all: 'ok',
   contains: true,
@@ -32,7 +30,7 @@ getLatestTag(options, function(err, tag) {
 ### Use as a readable stream
 
 ```js
-var getLatestTag = require('git-latest-tag');
+var getLatestTag = require('git-latest-tag').getLatestTag;
 var options = {
   all: 'ok',
   contains: true,
@@ -44,6 +42,21 @@ getLatestTag(options)
   .pipe(...);
 ```
 
+### Use it synchronously
+
+```js
+var getLatestTagSync = require('git-latest-tag').getLatestTagSync;
+var options = {
+  all: 'ok',
+  contains: true,
+  candidates: 10,
+  'commit-ish': 'HEAD'
+};
+
+var tag = getLatestTagSync(options);
+console.log(tag);
+//=> latestTag
+```
 
 ## API
 
@@ -59,17 +72,26 @@ All options will be dash-cased for you.
 
 Please check the available options at http://git-scm.com/docs/git-describe.
 
+You can also define a specific Git repo other than the current path through the 'repoPath' option:
+
+```js
+// Options to get latest tag from current branch of a given repo
+var options = {
+  tags: true,
+  abbrev: 0,
+  repoPath: '/path/to/repo'
+};
+```
+
 *NOTE*: if a flag takes no value and the passed `options.value` is truthy, it will generate the flag only without any value. If it's falsy the flag will not be included.
 
 If it's a `true`, it will suppress long format, only showing the closest tag in refs/tags namespace and will return an empty string if there is no tags but more than one commit (same as `{ tags: true, abbrev: 0 }`).
 
 #### callback(err, tag)
 
-
 ## License
 
 MIT © [Steve Mao](https://github.com/stevemao)
-
 
 [npm-image]: https://badge.fury.io/js/git-latest-tag.svg
 [npm-url]: https://npmjs.org/package/git-latest-tag

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 > Get the most recent git tag of your repository using git-describe(1)
 
+
 ## Install
 
 ```sh
 $ npm install --save git-latest-tag
 ```
+
 
 ## Usage
 
@@ -42,21 +44,6 @@ getLatestTag(options)
   .pipe(...);
 ```
 
-### Use it synchronously
-
-```js
-var getLatestTagSync = require('git-latest-tag').sync;
-var options = {
-  all: 'ok',
-  contains: true,
-  candidates: 10,
-  'commit-ish': 'HEAD'
-};
-
-var tag = getLatestTagSync(options);
-console.log(tag);
-//=> latestTag
-```
 
 ## API
 
@@ -72,26 +59,17 @@ All options will be dash-cased for you.
 
 Please check the available options at http://git-scm.com/docs/git-describe.
 
-You can also define a specific Git repo other than the current path through the 'repoPath' option:
-
-```js
-// Options to get latest tag from current branch of a given repo
-var options = {
-  tags: true,
-  abbrev: 0,
-  repoPath: '/path/to/repo'
-};
-```
-
 *NOTE*: if a flag takes no value and the passed `options.value` is truthy, it will generate the flag only without any value. If it's falsy the flag will not be included.
 
 If it's a `true`, it will suppress long format, only showing the closest tag in refs/tags namespace and will return an empty string if there is no tags but more than one commit (same as `{ tags: true, abbrev: 0 }`).
 
 #### callback(err, tag)
 
+
 ## License
 
 MIT © [Steve Mao](https://github.com/stevemao)
+
 
 [npm-image]: https://badge.fury.io/js/git-latest-tag.svg
 [npm-url]: https://npmjs.org/package/git-latest-tag

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 var exec = require('child_process').exec;
-var execSync = require('sync-exec');
+var execSync = require('runsync').exec;
 var decamelize = require('decamelize');
 var _ = require('lodash');
 
@@ -89,12 +89,9 @@ function getLatestTagSync(opts) {
 
   var execOpts = getExecOptions(opts);
   var cmd = getCmd(opts);
-  var res = execSync(cmd, execOpts);
+  var stdout = execSync(cmd, execOpts);
 
-  if(res.status !== 0) {
-    throw new Error(String(res.stderr).trim());
-  }
-  return String(res.stdout).trim();
+  return String(stdout).trim();
 }
 
 getLatestTag.sync = getLatestTagSync;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 var exec = require('child_process').exec;
-var execSync = require('runsync').exec;
+var execSync = require('child_process').execSync || require('runsync').exec;
 var decamelize = require('decamelize');
 var _ = require('lodash');
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 var exec = require('child_process').exec;
+var execSync = require('child_process').execSync;
 var decamelize = require('decamelize');
 var _ = require('lodash');
 
@@ -50,6 +51,18 @@ function getCmd(opts) {
   return cmd;
 }
 
+function getExecOptions(opts) {
+
+  var execOpts = {};
+
+  if (opts instanceof Object && "repoPath" in opts) {
+    execOpts.cwd = opts.repoPath;
+    delete opts.repoPath;
+  }
+
+  return execOpts;
+}
+
 function getLatestTag(opts, cb) {
   if (typeof opts === 'function') {
     cb = opts;
@@ -58,9 +71,10 @@ function getLatestTag(opts, cb) {
     cb = cb || function() {};
   }
 
+  var execOpts = getExecOptions(opts);
   var cmd = getCmd(opts);
 
-  return exec(cmd, function(err, stdout) {
+  return exec(cmd, execOpts, function(err, stdout) {
     if (err) {
       cb(err);
     } else {
@@ -69,4 +83,15 @@ function getLatestTag(opts, cb) {
   }).stdout;
 }
 
-module.exports = getLatestTag;
+function getLatestTagSync(opts) {
+
+  if(opts === null) opts = {};
+
+  var execOpts = getExecOptions(opts);
+  var cmd = getCmd(opts);
+  var stdout = execSync(cmd, execOpts);
+
+  return String(stdout).trim();
+}
+
+module.exports = { getLatestTag: getLatestTag, getLatestTagSync: getLatestTagSync };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 var exec = require('child_process').exec;
-var execSync = require('child_process').execSync;
+var execSync = require('runsync').exec;
 var decamelize = require('decamelize');
 var _ = require('lodash');
 
@@ -94,4 +94,5 @@ function getLatestTagSync(opts) {
   return String(stdout).trim();
 }
 
-module.exports = { getLatestTag: getLatestTag, getLatestTagSync: getLatestTagSync };
+getLatestTag.sync = getLatestTagSync;
+module.exports = getLatestTag;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 var exec = require('child_process').exec;
-var execSync = require('runsync').exec;
+var execSync = require('sync-exec');
 var decamelize = require('decamelize');
 var _ = require('lodash');
 
@@ -89,9 +89,12 @@ function getLatestTagSync(opts) {
 
   var execOpts = getExecOptions(opts);
   var cmd = getCmd(opts);
-  var stdout = execSync(cmd, execOpts);
+  var res = execSync(cmd, execOpts);
 
-  return String(stdout).trim();
+  if(res.status !== 0) {
+    throw new Error(String(res.stderr).trim());
+  }
+  return String(res.stdout).trim();
 }
 
 getLatestTag.sync = getLatestTagSync;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "decamelize": "^1.0.0",
-    "lodash": "^3.3.1"
+    "lodash": "^3.3.1",
+    "runsync": "^0.1.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
   "dependencies": {
     "decamelize": "^1.0.0",
     "lodash": "^3.3.1",
-    "runsync": "^0.1.8"
+    "sync-exec": "^0.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
   "dependencies": {
     "decamelize": "^1.0.0",
     "lodash": "^3.3.1",
-    "sync-exec": "^0.6.1"
+    "runsync": "^0.1.8"
   }
 }

--- a/test.js
+++ b/test.js
@@ -76,6 +76,13 @@ it('should\'t work without options', function(done) {
   });
 });
 
+it('should\'t work with invalid custom repo path', function(done) {
+  gitLatestTag({repoPath: './somewhere'}, function(err, tag) {
+      assert(err);
+      return done();
+  });
+});
+
 it('should work syncronously with true flag', function() {
   var tag = gitLatestTagSync(true);
   assert.equal(tag.indexOf('v'), 0);
@@ -86,10 +93,10 @@ it('should work syncronously with custom repo path', function() {
   assert.equal(tag.indexOf('v'), 0);
 });
 
-it('shouldn\'t work syncronously with wrong custom repo path', function() {
+it('shouldn\'t work syncronously with invalid custom repo path', function() {
   assert.throws(
     function() {
-      var tag = gitLatestTagSync({abbrev: 0, tags: true, repoPath: "./somewhere"});
+      var tag = gitLatestTagSync({abbrev: 0, tags: true, repoPath: './somewhere'});
     },
     Error
   );

--- a/test.js
+++ b/test.js
@@ -1,11 +1,13 @@
 /*global it */
 'use strict';
-var assert = require('assert');
-var through = require('through2');
-var rewire = require('rewire');
-var gitLatestTag = rewire('./');
+var assert	= require('assert');
+var through	= require('through2');
+var rewire	= require('rewire');
 
-var getCmd = gitLatestTag.__get__('getCmd');
+var gitLatestTagModule	= rewire('./');
+var getCmd		= gitLatestTagModule.__get__('getCmd');
+var gitLatestTag	= gitLatestTagModule.getLatestTag;
+var gitLatestTagSync	= gitLatestTagModule.getLatestTagSync;
 
 it('without options', function() {
   var cmd = getCmd();
@@ -67,13 +69,28 @@ it('should callback with options', function(done) {
   });
 });
 
-it('should callback without options', function(done) {
+it('should\'t work without options', function(done) {
   gitLatestTag(function(err, tag) {
-    if (err) {
       assert(err);
       return done();
-    }
-    assert.equal(tag.indexOf('v'), 0);
-    done();
   });
+});
+
+it('should work syncronously with true flag', function() {
+  var tag = gitLatestTagSync(true);
+  assert.equal(tag.indexOf('v'), 0);
+});
+
+it('should work syncronously with custom repo path', function() {
+  var tag = gitLatestTagSync({abbrev: 0, tags: true, repoPath: "."});
+  assert.equal(tag.indexOf('v'), 0);
+});
+
+it('shouldn\'t work syncronously with wrong custom repo path', function() {
+  assert.throws(
+    function() {
+      var tag = gitLatestTagSync({abbrev: 0, tags: true, repoPath: "./somewhere"});
+    },
+    Error
+  );
 });

--- a/test.js
+++ b/test.js
@@ -76,6 +76,13 @@ it('should\'t work without options', function(done) {
   });
 });
 
+it('should\'t work with invalid custom path', function(done) {
+  gitLatestTag({repoPath: "./somewhere"}, function(err, tag) {
+      assert(err);
+      return done();
+  });
+});
+
 it('should work syncronously with true flag', function() {
   var tag = gitLatestTagSync(true);
   assert.equal(tag.indexOf('v'), 0);
@@ -86,7 +93,7 @@ it('should work syncronously with custom repo path', function() {
   assert.equal(tag.indexOf('v'), 0);
 });
 
-it('shouldn\'t work syncronously with wrong custom repo path', function() {
+it('shouldn\'t work syncronously with invalid custom repo path', function() {
   assert.throws(
     function() {
       var tag = gitLatestTagSync({abbrev: 0, tags: true, repoPath: "./somewhere"});

--- a/test.js
+++ b/test.js
@@ -76,13 +76,6 @@ it('should\'t work without options', function(done) {
   });
 });
 
-it('should\'t work with invalid custom path', function(done) {
-  gitLatestTag({repoPath: "./somewhere"}, function(err, tag) {
-      assert(err);
-      return done();
-  });
-});
-
 it('should work syncronously with true flag', function() {
   var tag = gitLatestTagSync(true);
   assert.equal(tag.indexOf('v'), 0);
@@ -93,7 +86,7 @@ it('should work syncronously with custom repo path', function() {
   assert.equal(tag.indexOf('v'), 0);
 });
 
-it('shouldn\'t work syncronously with invalid custom repo path', function() {
+it('shouldn\'t work syncronously with wrong custom repo path', function() {
   assert.throws(
     function() {
       var tag = gitLatestTagSync({abbrev: 0, tags: true, repoPath: "./somewhere"});

--- a/test.js
+++ b/test.js
@@ -4,10 +4,10 @@ var assert	= require('assert');
 var through	= require('through2');
 var rewire	= require('rewire');
 
-var gitLatestTagModule	= rewire('./');
-var getCmd		= gitLatestTagModule.__get__('getCmd');
-var gitLatestTag	= gitLatestTagModule.getLatestTag;
-var gitLatestTagSync	= gitLatestTagModule.getLatestTagSync;
+var gitLatestTag	= rewire('./');
+var getCmd		= gitLatestTag.__get__('getCmd');
+var gitLatestTag	= gitLatestTag;
+var gitLatestTagSync	= gitLatestTag.sync;
 
 it('without options', function() {
   var cmd = getCmd();


### PR DESCRIPTION
I added support for sync operations, so now the module returns two functions (async and sync).
I also added the option to define a specific git repo path instead of the current path.
Finally, both features were included in the README and in the test, see what you think.
